### PR TITLE
PHP.ini location

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -375,6 +375,10 @@ The `nginx-error.log`, `php.log` and `mysql.log` are located at `~/.valet/Log`.
 
 Other logs are located at `/usr/local/var/log`
 
+## PHP.ini location
+
+The PHP.ini location is `/usr/local/etc/php/VERSION/php.ini`.
+
 ## Valet drivers
 Valet uses drivers to handle requests. You can read more about those [here](https://laravel.com/docs/5.4/valet#custom-valet-drivers).
 


### PR DESCRIPTION
Adds the location of PHP.ini to the readme/documentation. Would have helped me today, so it might help others as well.